### PR TITLE
Add info icon by store details

### DIFF
--- a/src/pages/Store/Store/Store.tsx
+++ b/src/pages/Store/Store/Store.tsx
@@ -882,8 +882,8 @@ export const Store = () => {
                 }}
               >
                 {username === user?.name
-                  ? currentStore?.title
-                  : currentViewedStore?.title}
+                  ? currentStore?.title + " 🛈"
+                  : currentViewedStore?.title + " 🛈"}
               </StoreTitle>
               {averageRatingLoader ? (
                 <CircularProgress />


### PR DESCRIPTION
This adds an info icon next to the shop's title on the individual store pages.  It should help draw attention so customers are more likely to notice the link that displays the shop details.  The details are not shown anywhere else, and it's very unintuitive for users to think to click the title of the store page that they are already viewing.  Having this icon makes it clear there is a reason to interact with that element, and the underline that appears when hovering would show that it is a clickable link.  This has been published to QDN at `qortal://app/QM-Shop` to facilitate testing.